### PR TITLE
vkd3d: Disable VK_EXT_descriptor_indexing.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -131,7 +131,11 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
     VK_EXTENSION(EXT_DEBUG_MARKER, EXT_debug_marker),
     VK_EXTENSION(EXT_DEPTH_CLIP_ENABLE, EXT_depth_clip_enable),
-    VK_EXTENSION(EXT_DESCRIPTOR_INDEXING, EXT_descriptor_indexing),
+    /* Just enabling descriptor indexing on RADV currently hits pathological frame pacing behavior.
+     * It is currently not really used for anything, so just don't enable it for now.
+     * See https://gitlab.freedesktop.org/mesa/mesa/2529
+     * VK_EXTENSION(EXT_DESCRIPTOR_INDEXING, EXT_descriptor_indexing),
+     */
     VK_EXTENSION(EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION, EXT_shader_demote_to_helper_invocation),
     VK_EXTENSION(EXT_TEXEL_BUFFER_ALIGNMENT, EXT_texel_buffer_alignment),
     VK_EXTENSION(EXT_TRANSFORM_FEEDBACK, EXT_transform_feedback),


### PR DESCRIPTION
Currently hits pathological frame pacing behavior on RADV.
Since this extension is currently unused, this is a trivial fix for the
time being.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>